### PR TITLE
ISSUE-30: Add embed feature

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -19,6 +19,7 @@
         <FIELD NAME="sortby" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="postby" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="userscanedit" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="embed" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -74,5 +74,21 @@ function xmldb_board_upgrade(int $oldversion) {
         upgrade_mod_savepoint(true, 2021052407, 'board');
     }
 
+    if ($oldversion < 2021052408) {
+
+        // Define field embed to be added to board.
+        $table = new xmldb_table('board');
+        $field = new xmldb_field('embed', XMLDB_TYPE_INTEGER, '1', null, null, null, '0', 'userscanedit');
+
+        // Conditionally launch add field embed.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Board savepoint reached.
+        upgrade_mod_savepoint(true, 2021052408, 'board');
+
+    }
+
     return true;
 }

--- a/lang/en/board.php
+++ b/lang/en/board.php
@@ -87,6 +87,10 @@ $string['history_refresh'] = 'Board refresh timer';
 $string['history_refresh_desc'] = 'Timeout in seconds between automatic board refreshes. If set to 0 or empty then the board will only refresh during board actions (add/update/etc)';
 $string['column_colours'] = 'Column Colours';
 $string['column_colours_desc'] = 'The colours used at the top of each column. These are hex colors and should be placed once per line as 3 or 6 characters. If any of these values are not equal to a colour then the defaults will be used.';
+$string['embed_width'] = 'Embed width';
+$string['embed_width_desc'] = 'Width to use for the iframe when embedding the board within the course. This should be a valid CSS value, e.g. px, rem, %, etc...';
+$string['embed_height'] = 'Embed height';
+$string['embed_height_desc'] = 'Height to use for the iframe when embedding the board within the course. This should be a valid CSS value, e.g. px, rem, %, etc...';
 
 $string['export_board'] = 'Export CSV';
 $string['export_submissions'] = 'Export Submissions';
@@ -152,6 +156,7 @@ $string['postbydate'] = 'Post by date';
 $string['boardsettings'] = 'Board settings';
 $string['postbyenabled'] = 'Limit students posting by date';
 $string['userscanedit'] = 'Allow all users to edit the placement of their own posts.';
+$string['embedboard'] = 'Embed the board into the course page';
 
 $string['invalid_youtube_url'] = 'Invalid YouTube URL';
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -92,6 +92,9 @@ class mod_board_mod_form extends moodleform_mod {
 
         $mform->addElement('advcheckbox', 'userscanedit', get_string('userscanedit', 'mod_board'));
 
+        // Embed board on the course, rather then give a link to it.
+        $mform->addElement('advcheckbox', 'embed', get_string('embedboard', 'mod_board'));
+
         $this->standard_coursemodule_elements();
 
         $this->add_action_buttons();

--- a/settings.php
+++ b/settings.php
@@ -59,4 +59,10 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    $settings->add(new admin_setting_configtext('mod_board/embed_width', get_string('embed_width', 'mod_board'),
+                       get_string('embed_width_desc', 'mod_board'), '99%', PARAM_TEXT));
+
+    $settings->add(new admin_setting_configtext('mod_board/embed_height', get_string('embed_height', 'mod_board'),
+                       get_string('embed_height_desc', 'mod_board'), '500px', PARAM_TEXT));
+
 }

--- a/styles.css
+++ b/styles.css
@@ -257,8 +257,12 @@
     padding: 2px 8px 0;
 }
 
-/* Adjust the flex-fill div to 100% width not using normal view link. */
 .modtype_board div.flex-fill {
+    width: 100%;
+}
+
+.modtype_board div.contentwithoutlink {
+    display: block !important;
     width: 100%;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -256,3 +256,12 @@
 .delete_note {
     padding: 2px 8px 0;
 }
+
+/* Adjust the flex-fill div to 100% width not using normal view link. */
+.modtype_board div.flex-fill {
+    width: 100%;
+}
+
+iframe.mod_board-iframe {
+    overflow-x: auto;
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'mod_board'; // Full name of the plugin (used for diagnostics).
-$plugin->version   = 2021052407; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2021052408; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2020061500; // Moodle 3.9 and up.
 $plugin->release = '1.39.06 (Build 2021101501)';
 $plugin->maturity  = MATURITY_STABLE;

--- a/view.php
+++ b/view.php
@@ -28,6 +28,7 @@ use mod_board\board;
 
 $id      = optional_param('id', 0, PARAM_INT); // Course Module ID.
 $b       = optional_param('b', 0, PARAM_INT);  // Board instance ID.
+$embed   = optional_param('embed', 0, PARAM_INT);
 
 if ($b) {
     if (!$board = $DB->get_record('board', array('id' => $b))) {
@@ -79,6 +80,11 @@ $PAGE->requires->js_call_amd('mod_board/main', 'initialize', array('board' => $b
 $PAGE->set_title(format_string($board->name));
 $PAGE->set_heading($course->fullname);
 $PAGE->set_activity_record($board);
+
+// If we are embedding the board on the course, set the layout to embedded to remove all other content.
+if ($embed) {
+    $PAGE->set_pagelayout('embedded');
+}
 
 echo $OUTPUT->header();
 


### PR DESCRIPTION
This commit adds the ability to set a board activity to be embedded within the course page, rather than just a link to it.

It also adds:
- Plugin setting for default width/height
- Column 'embed' to {board} DB table
- Lang strings
- Version bump


Had this as a feature request from a college, and also saw it was requested by someone else in the issue tracker.

Implements #30 