### PR TITLE
Consistently apply max length limits

### DIFF
--- a/classes/board.php
+++ b/classes/board.php
@@ -312,7 +312,7 @@ class board {
     public static function board_add_column(int $boardid, string $name): array {
         global $DB, $USER;
 
-        $name = substr($name, 0, 100);
+        $name = mb_substr($name, 0, 100);
 
         static::require_capability_for_board($boardid);
 
@@ -358,7 +358,7 @@ class board {
     public static function board_update_column(int $id, string $name): array {
         global $DB, $USER;
 
-        $name = substr($name, 0, 100);
+        $name = mb_substr($name, 0, 100);
 
         static::require_capability_for_column($id);
 
@@ -609,8 +609,8 @@ class board {
             require_capability('mod/board:view', $context);
         }
 
-        $heading = empty($heading) ? null : substr($heading, 0, 100);
-        $content = empty($content) ? "" : substr($content, 0, get_config('mod_board', 'post_max_length'));
+        $heading = empty($heading) ? null : mb_substr($heading, 0, 100);
+        $content = empty($content) ? "" : mb_substr($content, 0, get_config('mod_board', 'post_max_length'));
         $content = clean_text($content, FORMAT_HTML);
 
         $boardid = $DB->get_field('board_columns', 'boardid', array('id' => $columnid));
@@ -627,8 +627,8 @@ class board {
             }
             $transaction = $DB->start_delegated_transaction();
             $type = !empty($attachment['type']) ? $attachment['type'] : 0;
-            $info = !empty($type) ? substr(s($attachment['info']), 0, 100) : null;
-            $url = !empty($type) ? substr($attachment['url'], 0, 200) : null;
+            $info = !empty($type) ? mb_substr(s($attachment['info']), 0, 100) : null;
+            $url = !empty($type) ? mb_substr($attachment['url'], 0, 200) : null;
 
             $notecreated = time();
             $noteid = $DB->insert_record('board_notes', array('groupid' => $groupid, 'columnid' => $columnid,
@@ -701,8 +701,8 @@ class board {
 
         static::require_capability_for_note($id);
 
-        $heading = empty($heading) ? null : substr($heading, 0, 100);
-        $content = empty($content) ? "" : substr($content, 0, get_config('mod_board', 'post_max_length'));
+        $heading = empty($heading) ? null : mb_substr($heading, 0, 100);
+        $content = empty($content) ? "" : mb_substr($content, 0, get_config('mod_board', 'post_max_length'));
         $content = clean_text($content, FORMAT_HTML);
 
         $note = static::get_note($id);
@@ -723,8 +723,8 @@ class board {
             $attachment = static::board_note_update_attachment($id, $attachment, $previoustype);
 
             $type = !empty($attachment['type']) ? $attachment['type'] : 0;
-            $info = !empty($type) ? substr(s($attachment['info']), 0, 100) : null;
-            $url = !empty($type) ? substr($attachment['url'], 0, 200) : null;
+            $info = !empty($type) ? mb_substr(s($attachment['info']), 0, 100) : null;
+            $url = !empty($type) ? mb_substr($attachment['url'], 0, 200) : null;
 
             $historyid = $DB->insert_record('board_history', array('boardid' => $boardid, 'action' => 'update_note',
                                             'userid' => $USER->id, 'content' => json_encode(array('id' => $id,

--- a/classes/note_form.php
+++ b/classes/note_form.php
@@ -53,7 +53,6 @@ class note_form extends \moodleform {
         $options = ['maxlength' => $maxlen, 'cols' => 30, 'rows' => 3];
         $mform->addElement('textarea', 'content', get_string('form_body', 'mod_board'), $options);
         $mform->setType('content', PARAM_TEXT);
-        $mform->addRule('content', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
         $options = [
             0 => get_string('option_empty', 'mod_board'),

--- a/classes/note_form.php
+++ b/classes/note_form.php
@@ -47,13 +47,13 @@ class note_form extends \moodleform {
         $maxlen = 100;
         $mform->addElement('text', 'heading', get_string('form_title', 'mod_board'), ['maxlength' => $maxlen]);
         $mform->setType('heading', PARAM_TEXT);
-        $mform->addRule('heading', get_string('maximumchars', '', $maxlen), 'maxlength', 255, 'client');
+        $mform->addRule('heading', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
         $maxlen = $config->post_max_length;
         $options = ['maxlength' => $maxlen, 'cols' => 30, 'rows' => 3];
         $mform->addElement('textarea', 'content', get_string('form_body', 'mod_board'), $options);
         $mform->setType('content', PARAM_TEXT);
-        $mform->addRule('content', get_string('maximumchars', '', $maxlen), 'maxlength', 255, 'client');
+        $mform->addRule('content', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
         $options = [
             0 => get_string('option_empty', 'mod_board'),
@@ -73,37 +73,42 @@ class note_form extends \moodleform {
         $mform->addElement('static', 'mediabuttons', get_string('form_mediatype', 'mod_board'), $html);
 
         // Link.
-        $options = ['maxlength' => 100, 'placeholder' => get_string('option_link_info', 'mod_board')];
+        $maxlen = 100;
+        $options = ['maxlength' => $maxlen, 'placeholder' => get_string('option_link_info', 'mod_board')];
         $mform->addElement('text', 'linktitle', get_string('option_link_info', 'mod_board'), $options);
         $mform->setType('linktitle', PARAM_TEXT);
         $mform->hideIf('linktitle', 'mediatype', 'neq', 3);
-        $mform->addRule('linktitle', get_string('maximumchars', '', $maxlen), 'maxlength', 255, 'client');
+        $mform->addRule('linktitle', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
-        $attr = ['maxlength' => 200, 'placeholder' => get_string('option_link_url', 'mod_board')];
+        $maxlen = 200;
+        $attr = ['maxlength' => $maxlen, 'placeholder' => get_string('option_link_url', 'mod_board')];
         $mform->addElement('url', 'linkurl', get_string('option_link_url', 'mod_board'), $attr, ['usefilepicker' => false]);
         $mform->setType('linkurl', PARAM_URL);
         $mform->hideIf('linkurl', 'mediatype', 'neq', 3);
-        $mform->addRule('linkurl', get_string('maximumchars', '', $maxlen), 'maxlength', 255, 'client');
+        $mform->addRule('linkurl', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
         // YouTube video.
-        $options = ['maxlength' => 100, 'placeholder' => get_string('option_youtube_info', 'mod_board')];
+        $maxlen = 100;
+        $options = ['maxlength' => $maxlen, 'placeholder' => get_string('option_youtube_info', 'mod_board')];
         $mform->addElement('text', 'youtubetitle', get_string('option_youtube_info', 'mod_board'), $options);
         $mform->setType('youtubetitle', PARAM_TEXT);
         $mform->hideIf('youtubetitle', 'mediatype', 'neq', 1);
-        $mform->addRule('youtubetitle', get_string('maximumchars', '', $maxlen), 'maxlength', 255, 'client');
+        $mform->addRule('youtubetitle', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
-        $options = ['maxlength' => 200, 'placeholder' => get_string('option_youtube_url', 'mod_board')];
+        $maxlen = 200;
+        $options = ['maxlength' => $maxlen, 'placeholder' => get_string('option_youtube_url', 'mod_board')];
         $mform->addElement('text', 'youtubeurl', get_string('option_youtube_url', 'mod_board'), $options);
         $mform->setType('youtubeurl', PARAM_URL);
         $mform->hideIf('youtubeurl', 'mediatype', 'neq', 1);
-        $mform->addRule('youtubeurl', get_string('maximumchars', '', $maxlen), 'maxlength', 255, 'client');
+        $mform->addRule('youtubeurl', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
         // Image file.
-        $options = ['maxlength' => 100, 'placeholder' => get_string('option_image_info', 'mod_board')];
+        $maxlen = 100;
+        $options = ['maxlength' => $maxlen, 'placeholder' => get_string('option_image_info', 'mod_board')];
         $mform->addElement('text', 'imagetitle', get_string('option_image_info', 'mod_board'), $options);
         $mform->setType('imagetitle', PARAM_TEXT);
         $mform->hideIf('imagetitle', 'mediatype', 'neq', 2);
-        $mform->addRule('imagetitle', get_string('maximumchars', '', $maxlen), 'maxlength', 255, 'client');
+        $mform->addRule('imagetitle', get_string('maximumchars', '', $maxlen), 'maxlength', $maxlen, 'client');
 
         $pickerparams = board::get_image_picker_options();
         $mform->addElement('filemanager', 'imagefile', get_string('form_image_file', 'mod_board'), null, $pickerparams);

--- a/view.php
+++ b/view.php
@@ -63,7 +63,6 @@ $PAGE->requires->js_call_amd('mod_board/main', 'initialize', array('board' => $b
     'columnicon' => $config->new_column_icon,
     'noteicon' => $config->new_note_icon,
     'mediaselection' => $config->media_selection,
-    'post_max_length' => $config->post_max_length,
     'history_refresh' => $config->history_refresh,
     'file' => array(
         'extensions' => explode(',', board::ACCEPTED_FILE_EXTENSIONS),


### PR DESCRIPTION
This fix...

* applies the max length limits for all the input fields consistently
* removes the mform maxlength rule on the content input (because the check does not work well and the limits are enforced anyway)
* replaces `substr()` with `mb_substr()` to account for multi-byte-characters

... thus fixing #43 

Things to note for future work:
* The 'maxlength' form rules (`$mform->addRule`) usually don't kick in because of the limit also applied to input element itself. Therefore the browser enforces the limit by don't letting the user put in more characters than allowed
  * Constructed tests with a lower number on the rule showed that the error message will not reliably shown
  * When the validation fails, the submission is not prevented
  * with line breaks the validation on client-side does not seem to be consistent with server-side validation on edge-cases (client-side validation OK while server-side validation fails)
* Silently truncate user input on server side is not good practice. Even though it should not happen anymore as long as the form was not tampered (avoid client-side validation) it is better to throw an exception instead.