### PR TITLE
Issue 48: Fix invalid external service parameter type

### DIFF
--- a/external.php
+++ b/external.php
@@ -88,7 +88,7 @@ class mod_board_external extends external_api {
     public static function get_board_parameters(): external_function_parameters {
         return new external_function_parameters([
             'id' => new external_value(PARAM_INT, 'The board id', VALUE_REQUIRED),
-            'ownerid' => new external_value(PARAM_INT, 'The ownerid', VALUE_OPTIONAL)
+            'ownerid' => new external_value(PARAM_INT, 'The ownerid', VALUE_DEFAULT, 0)
         ]);
     }
 


### PR DESCRIPTION
The parameter is now optional to pass to the web service, when it is not used 0 will be sent instead which is the default used in the rest of the code for the owner id.