### PR TITLE
unpinned mariadb in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - 5432:5432
 
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:10
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"


### PR DESCRIPTION
MariaDB > 10.5 required for testing against MOODLE_402_STABLE and above.