### PR TITLE
Showownerofcomments moodle 401 stable

### DIFF
--- a/backup/moodle2/backup_board_stepslib.php
+++ b/backup/moodle2/backup_board_stepslib.php
@@ -33,7 +33,7 @@ class backup_board_activity_structure_step extends backup_activity_structure_ste
 
         $board = new backup_nested_element('board', array('id'), array(
             'course', 'name', 'timemodified', 'intro', 'introformat', 'historyid',
-            'background_color', 'addrating', 'hideheaders', 'sortby', 'postby', 'userscanedit', 'singleusermode',
+            'background_color', 'showcommentusername', 'addrating', 'hideheaders', 'sortby', 'postby', 'userscanedit', 'singleusermode',
             'completionnotes'));
 
         $columns = new backup_nested_element('columns');

--- a/classes/board.php
+++ b/classes/board.php
@@ -319,7 +319,6 @@ class board {
         return $DB->count_records_sql($sql, ['boardid' => $boardid]) > 0;
     }
 
-
     /**
      * Retrieves the board.
      *
@@ -1156,10 +1155,6 @@ class board {
 
         return !empty($board->showcommentusername);
     }
-
-
-
-
 
     /**
      * Checks to see if the user can rate the note.

--- a/classes/board.php
+++ b/classes/board.php
@@ -113,6 +113,7 @@ class board {
                 'size_min' => self::ACCEPTED_FILE_MIN_SIZE,
                 'size_max' => self::ACCEPTED_FILE_MAX_SIZE
             ],
+                'showcommentusername' => self::board_showcommentusername($board->id),
             'ratingenabled' => self::board_rating_enabled($board->id),
             'hideheaders' => self::board_hide_headers($board->id),
             'sortby' => $board->sortby,
@@ -1138,6 +1139,27 @@ class board {
         ));
         $event->trigger();
     }
+
+
+
+    /**
+     * Checks to see if showcommentusername has been enabled for the board.
+     *
+     * @param int $boardid
+     * @return bool
+     */
+    public static function board_showcommentusername($boardid) {
+        $board = static::get_board($boardid);
+        if (!$board) {
+            return false;
+        }
+
+        return !empty($board->showcommentusername);
+    }
+
+
+
+
 
     /**
      * Checks to see if the user can rate the note.

--- a/classes/board.php
+++ b/classes/board.php
@@ -113,7 +113,7 @@ class board {
                 'size_min' => self::ACCEPTED_FILE_MIN_SIZE,
                 'size_max' => self::ACCEPTED_FILE_MAX_SIZE
             ],
-                'showcommentusername' => self::board_showcommentusername($board->id),
+            'showcommentusername' => self::board_show_commentusername($board->id),
             'ratingenabled' => self::board_rating_enabled($board->id),
             'hideheaders' => self::board_hide_headers($board->id),
             'sortby' => $board->sortby,
@@ -1148,7 +1148,7 @@ class board {
      * @param int $boardid
      * @return bool
      */
-    public static function board_showcommentusername($boardid) {
+    public static function board_show_commentusername($boardid) {
         $board = static::get_board($boardid);
         if (!$board) {
             return false;

--- a/db/install.xml
+++ b/db/install.xml
@@ -14,6 +14,7 @@
         <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="historyid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="background_color" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="showcommentusername" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="show username of comments to students"/>
         <FIELD NAME="addrating" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="hideheaders" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="show headers to students"/>
         <FIELD NAME="sortby" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -211,7 +211,6 @@ function xmldb_board_upgrade(int $oldversion) {
         upgrade_mod_savepoint(true, 2022040109, 'board');
     }
 
-
     if ($oldversion < 2023101902) {
 
         // Define field sortorder to be added to board_notes.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -211,5 +211,21 @@ function xmldb_board_upgrade(int $oldversion) {
         upgrade_mod_savepoint(true, 2022040109, 'board');
     }
 
+
+    if ($oldversion < 2023101902) {
+
+        // Define field sortorder to be added to board_notes.
+        $table = new xmldb_table('board');
+        $field = new xmldb_field('showcommentusername', XMLDB_TYPE_INTEGER, '1', null, null, null, '0', 'background_color');
+
+        // Conditionally launch add field sortorder.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Board savepoint reached.
+        upgrade_mod_savepoint(true, 2023101902, 'board');
+    }
+
     return true;
 }

--- a/external.php
+++ b/external.php
@@ -702,43 +702,34 @@ class mod_board_external extends external_api {
         $canpost = has_capability('mod/board:postcomment', $context);
         $candeleteall = has_capability('mod/board:deleteallcomments', $context);
 
-        $notes = $DB->get_records('board_comments', ['noteid' => $params['noteid']], 'timecreated DESC');
-        // von der noteid = 2 (tabele comments)
-        // noteid wird ja schon der Funktion übergeben und ist schon verfügbar
-        $params['id'] = $noteid;
-        // in Tabelle board_notes nach columnid für id=noteid ermitteln
-        $column = $DB->get_record('board_notes', ['id' => $params['id']], 'columnid, ownerid');
-        // die columns id = 3 und die ownerid 3 (tabeller notes)
-        $params['id'] = $column->columnid;
-        $board = $DB->get_record('board_columns', ['id' => $params['id']], 'boardid');
+        // Find the columnid for the note with the given noteid.
+        $params['noteid'] = $noteid;
+        $column = $DB->get_record('board_notes', ['id' => $params['noteid']], 'columnid, ownerid');
+
+        // Find the boardid of the column.
+        $params['columnid'] = $column->columnid;
+        $board = $DB->get_record('board_columns', ['id' => $params['columnid']], 'boardid');
+
+        // $board->boardid Ownerid is not relevant but we use $column->ownerid.
         $configuration = board::get_configuration($board->boardid, $column->ownerid);
         $showcommentusername = $configuration['showcommentusername'];
 
+        $notecomments = $DB->get_records('board_comments', ['noteid' => $params['noteid']], 'timecreated DESC');
         $comments = [];
-        foreach ($notes as $note) {
+        foreach ($notecomments as $notecomment) {
             $comment = (object)[];
-            $comment->id = $note->id;
-            $comment->noteid = $note->noteid;
-            $comment->content = $note->content;
-            $comment->candelete = ($note->userid === $USER->id || $candeleteall) ? true : false;
-
-            // ToDo: How should we control $canseecommentusername? Use capability (eg mod_board:canseecommentusername)?
-            // Moodleadmin can deside if the username of comments can be shown and visible to other users.
-            // By default it should be deactivated because in previous versions usernames were no visible and maybe there are allready
-            // boards that where used explicit without showing the usernames of comments ("anonym comments")
-            // commentusernamecanbevisible can be set by config-global.php or
-            //$canseecommentusername = get_config('mod_board', 'commentusernamecanbevisible');
-            //$canseecommentusername = true;
-
+            $comment->id = $notecomment->id;
+            $comment->noteid = $notecomment->noteid;
+            $comment->content = $notecomment->content;
+            $comment->candelete = ($notecomment->userid === $USER->id || $candeleteall) ? true : false;
             $comment->showcommentusername = $showcommentusername;
 
             $commentusername = '';
             $profilurl = '';
-
             if ($showcommentusername) {
-                $user = \core_user::get_user($note->userid, 'username, firstname, lastname');
+                $user = \core_user::get_user($notecomment->userid, 'username, firstname, lastname');
                 $commentusername = $user->firstname . " " . $user->lastname;
-                $profilurl = '' . new moodle_url('/user/profile.php', array('id' => $note->userid));
+                $profilurl = '' . new moodle_url('/user/profile.php', array('id' => $notecomment->userid));
             } else {
                 $commentusername = '';
                 $profilurl = '';
@@ -747,7 +738,7 @@ class mod_board_external extends external_api {
             $comment->commentusername = $commentusername;
             $comment->profilurl = $profilurl;
 
-            $comment->date = userdate($note->timecreated);
+            $comment->date = userdate($notecomment->timecreated);
             $comments[] = $comment;
         }
 
@@ -780,7 +771,7 @@ class mod_board_external extends external_api {
                             'id' => new external_value(PARAM_INT, 'The comment id.'),
                             'noteid' => new external_value(PARAM_INT, 'The note id.'),
                             'candelete' => new external_value(PARAM_BOOL, 'Can delete the comment.'),
-                               'showcommentusername' => new external_value(PARAM_BOOL, 'showcommentusername.'),
+                            'showcommentusername' => new external_value(PARAM_BOOL, 'showcommentusername.'),
                             'commentusername' => new external_value(PARAM_TEXT, 'The username of the comment.'),
                             'profilurl' => new external_value(PARAM_TEXT, 'The profil url of the user.'),
                             'date' => new external_value(PARAM_TEXT, 'The date of the comment.'),
@@ -934,7 +925,6 @@ class mod_board_external extends external_api {
         return new external_function_parameters([
             'id' => new external_value(PARAM_INT, 'The board id', VALUE_REQUIRED),
             'ownerid' => new external_value(PARAM_INT, 'The ownerid', VALUE_DEFAULT, 0),
-                'showcommentusername' => new external_value(PARAM_BOOL, 'showcommentusername', VALUE_DEFAULT, false),
         ]);
     }
 
@@ -944,12 +934,11 @@ class mod_board_external extends external_api {
      * @param int $ownerid
      * @return array
      */
-    public static function get_configuration(int $id, int $ownerid, bool $showcommentusername): array {
+    public static function get_configuration(int $id, int $ownerid): array {
         // Validate recieved parameters.
         $params = self::validate_parameters(self::get_configuration_parameters(), [
             'id' => $id,
             'ownerid' => $ownerid,
-            'showcommentusername' => $showcommentusername
         ]);
 
         // Request and permission validation.

--- a/external.php
+++ b/external.php
@@ -703,6 +703,17 @@ class mod_board_external extends external_api {
         $candeleteall = has_capability('mod/board:deleteallcomments', $context);
 
         $notes = $DB->get_records('board_comments', ['noteid' => $params['noteid']], 'timecreated DESC');
+        // von der noteid = 2 (tabele comments)
+        // noteid wird ja schon der Funktion übergeben und ist schon verfügbar
+        $params['id'] = $noteid;
+        // in Tabelle board_notes nach columnid für id=noteid ermitteln
+        $column = $DB->get_record('board_notes', ['id' => $params['id']], 'columnid, ownerid');
+        // die columns id = 3 und die ownerid 3 (tabeller notes)
+        $params['id'] = $column->columnid;
+        $board = $DB->get_record('board_columns', ['id' => $params['id']], 'boardid');
+        $configuration = board::get_configuration($board->boardid, $column->ownerid);
+        $showcommentusername = $configuration['showcommentusername'];
+
         $comments = [];
         foreach ($notes as $note) {
             $comment = (object)[];
@@ -710,6 +721,32 @@ class mod_board_external extends external_api {
             $comment->noteid = $note->noteid;
             $comment->content = $note->content;
             $comment->candelete = ($note->userid === $USER->id || $candeleteall) ? true : false;
+
+            // ToDo: How should we control $canseecommentusername? Use capability (eg mod_board:canseecommentusername)?
+            // Moodleadmin can deside if the username of comments can be shown and visible to other users.
+            // By default it should be deactivated because in previous versions usernames were no visible and maybe there are allready
+            // boards that where used explicit without showing the usernames of comments ("anonym comments")
+            // commentusernamecanbevisible can be set by config-global.php or
+            //$canseecommentusername = get_config('mod_board', 'commentusernamecanbevisible');
+            //$canseecommentusername = true;
+
+            $comment->showcommentusername = $showcommentusername;
+
+            $commentusername = '';
+            $profilurl = '';
+
+            if ($showcommentusername) {
+                $user = \core_user::get_user($note->userid, 'username, firstname, lastname');
+                $commentusername = $user->firstname . " " . $user->lastname;
+                $profilurl = '' . new moodle_url('/user/profile.php', array('id' => $note->userid));
+            } else {
+                $commentusername = '';
+                $profilurl = '';
+            }
+
+            $comment->commentusername = $commentusername;
+            $comment->profilurl = $profilurl;
+
             $comment->date = userdate($note->timecreated);
             $comments[] = $comment;
         }
@@ -743,6 +780,9 @@ class mod_board_external extends external_api {
                             'id' => new external_value(PARAM_INT, 'The comment id.'),
                             'noteid' => new external_value(PARAM_INT, 'The note id.'),
                             'candelete' => new external_value(PARAM_BOOL, 'Can delete the comment.'),
+                               'showcommentusername' => new external_value(PARAM_BOOL, 'showcommentusername.'),
+                            'commentusername' => new external_value(PARAM_TEXT, 'The username of the comment.'),
+                            'profilurl' => new external_value(PARAM_TEXT, 'The profil url of the user.'),
                             'date' => new external_value(PARAM_TEXT, 'The date of the comment.'),
                             'content' => new external_value(PARAM_RAW, 'The content of the comment.')
                         ]
@@ -894,6 +934,7 @@ class mod_board_external extends external_api {
         return new external_function_parameters([
             'id' => new external_value(PARAM_INT, 'The board id', VALUE_REQUIRED),
             'ownerid' => new external_value(PARAM_INT, 'The ownerid', VALUE_DEFAULT, 0),
+                'showcommentusername' => new external_value(PARAM_BOOL, 'showcommentusername', VALUE_DEFAULT, false),
         ]);
     }
 
@@ -903,11 +944,12 @@ class mod_board_external extends external_api {
      * @param int $ownerid
      * @return array
      */
-    public static function get_configuration(int $id, int $ownerid): array {
+    public static function get_configuration(int $id, int $ownerid, bool $showcommentusername): array {
         // Validate recieved parameters.
         $params = self::validate_parameters(self::get_configuration_parameters(), [
             'id' => $id,
             'ownerid' => $ownerid,
+            'showcommentusername' => $showcommentusername
         ]);
 
         // Request and permission validation.

--- a/lang/en/board.php
+++ b/lang/en/board.php
@@ -240,5 +240,3 @@ $string['showcommentusername_desc'] = 'If activated the username of a comment wi
 
 $string['showcommentusernameenabled'] = 'Show comment username is enabled.';
 $string['showcommentusernamedisabled'] = 'Show comment username is disabled but can be later activated to see the owner of comments.';
-
-

--- a/lang/en/board.php
+++ b/lang/en/board.php
@@ -234,3 +234,11 @@ $string['brickfieldlogo'] = 'Powered by Brickfield logo';
 $string['singleusermodenotembed'] = 'Board does not allow a single user board to be embedded. Please change your settings.';
 $string['allowed_singleuser_modes'] = 'Enabled single user modes';
 $string['allowed_singleuser_modes_desc'] = 'Allow/Disallow usage of certain single user modes. Does not affect already created boards';
+
+$string['showcommentusername'] = 'Show comment username';
+$string['showcommentusername_desc'] = 'If activated the username of a comment will be show for each comment.';
+
+$string['showcommentusernameenabled'] = 'Show comment username is enabled.';
+$string['showcommentusernamedisabled'] = 'Show comment username is disabled but can be later activated to see the owner of comments.';
+
+

--- a/mod_form.php
+++ b/mod_form.php
@@ -70,6 +70,27 @@ class mod_board_mod_form extends moodleform_mod {
         $mform->addElement('filemanager', 'background_image',
                 get_string('background_image', 'mod_board'), null, $filemanageroptions);
 
+/*
+        $mform->addElement('checkbox', 'showcommentusername',
+                get_string('showcommentusername', 'mod_board'),
+                get_string('showcommentusername_desc', 'mod_board'));
+        $mform->setDefault('showcommentusername', 1);
+        $mform->setType('showcommentusername', PARAM_INT);
+*/
+
+        $mform->addElement('checkbox', 'showcommentusername', get_string('showcommentusername', 'mod_board'));
+        //$mform->addHelpButton('showcommentusername', 'showcommentusername', 'mod_board');
+        //$mform->setDefault('showcommentusername', 0);
+        $mform->setType('showcommentusername', PARAM_INT);
+
+
+
+
+
+
+
+
+
         $mform->addElement('select', 'addrating', get_string('addrating', 'mod_board'),
            array(
                 board::RATINGDISABLED => get_string('addrating_none', 'mod_board'),

--- a/mod_form.php
+++ b/mod_form.php
@@ -69,27 +69,11 @@ class mod_board_mod_form extends moodleform_mod {
         $filemanageroptions['subdirs'] = 0;
         $mform->addElement('filemanager', 'background_image',
                 get_string('background_image', 'mod_board'), null, $filemanageroptions);
-
-/*
-        $mform->addElement('checkbox', 'showcommentusername',
-                get_string('showcommentusername', 'mod_board'),
-                get_string('showcommentusername_desc', 'mod_board'));
+        
+        $mform->addElement('advcheckbox', 'showcommentusername', get_string('showcommentusername', 'mod_board'));
+        $mform->addHelpButton('showcommentusername', 'showcommentusername', 'mod_board');
         $mform->setDefault('showcommentusername', 1);
         $mform->setType('showcommentusername', PARAM_INT);
-*/
-
-        $mform->addElement('checkbox', 'showcommentusername', get_string('showcommentusername', 'mod_board'));
-        //$mform->addHelpButton('showcommentusername', 'showcommentusername', 'mod_board');
-        //$mform->setDefault('showcommentusername', 0);
-        $mform->setType('showcommentusername', PARAM_INT);
-
-
-
-
-
-
-
-
 
         $mform->addElement('select', 'addrating', get_string('addrating', 'mod_board'),
            array(

--- a/mod_form.php
+++ b/mod_form.php
@@ -69,7 +69,7 @@ class mod_board_mod_form extends moodleform_mod {
         $filemanageroptions['subdirs'] = 0;
         $mform->addElement('filemanager', 'background_image',
                 get_string('background_image', 'mod_board'), null, $filemanageroptions);
-        
+
         $mform->addElement('advcheckbox', 'showcommentusername', get_string('showcommentusername', 'mod_board'));
         $mform->addHelpButton('showcommentusername', 'showcommentusername', 'mod_board');
         $mform->setDefault('showcommentusername', 1);

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -332,6 +332,9 @@
     .modal-footer [data-action="cancel"] {
         order: 1;
     }
+    .mod_board_comment_username {
+        margin-left: 10px;
+    }
 }
 .modtype_board div.flex-fill {
     width: 100%;

--- a/styles.css
+++ b/styles.css
@@ -358,3 +358,7 @@ iframe.mod_board-iframe {
 .pagelayout-embedded.path-mod-board .activity-header {
     display: none;
 }
+
+.mod_board-comment-username {
+    margin-left: 10px;
+}

--- a/styles.css
+++ b/styles.css
@@ -341,6 +341,10 @@
     order: 1;
 }
 
+.path-mod-board .mod_board_comment_username {
+    margin-left: 10px;
+}
+
 .modtype_board div.flex-fill {
     width: 100%;
 }
@@ -359,6 +363,3 @@ iframe.mod_board-iframe {
     display: none;
 }
 
-.mod_board-comment-username {
-    margin-left: 10px;
-}

--- a/templates/comments.mustache
+++ b/templates/comments.mustache
@@ -25,7 +25,7 @@
         "content": "This is a comment too",
         "date": "Wednesday, 2 January 2019, 12:00 AM",
         "comments": "Comment for testing",
-        "username": "Username of the autor of the Comment",
+        "commentusername": "Username of the autor of the Comment",
         "profilurl": "",
         "candelete": true,
         "showcommentusername": true
@@ -35,17 +35,14 @@
     <div class="comment border rounded border-light p-2 mb-2">
         <div class="comment-header d-flex small text-muted">
             <div class="mb-3">{{date}}</div>
-            <div class="mod_board-comment-username">
+            <div class="mod_board_comment_username">
                 {{#showcommentusername}}
                     {{#profilurl}}
-                        <a class="mod_boad-profilurl" href="{{profilurl}}">{{commentusername}}</a>
-                    {{/profilurl}}
-                    {{^profilurl}}
-                        {{commentusername}}
+                        <a class="mod_board_profilurl" href="{{profilurl}}">{{commentusername}}</a>
                     {{/profilurl}}
                 {{/showcommentusername}}
                 {{^showcommentusername}}
-                    (username wird aktuell nicht angezeigt)
+                    <!- (username hidden) -->
                 {{/showcommentusername}}
             </div>
             {{#candelete}}

--- a/templates/comments.mustache
+++ b/templates/comments.mustache
@@ -24,13 +24,30 @@
         "id": 2,
         "content": "This is a comment too",
         "date": "Wednesday, 2 January 2019, 12:00 AM",
-        "candelete": true
+        "comments": "Comment for testing",
+        "username": "Username of the autor of the Comment",
+        "profilurl": "",
+        "candelete": true,
+        "showcommentusername": true
     }
 }}
 {{#comments}}
     <div class="comment border rounded border-light p-2 mb-2">
         <div class="comment-header d-flex small text-muted">
             <div class="mb-3">{{date}}</div>
+            <div class="mod_board-comment-username">
+                {{#showcommentusername}}
+                    {{#profilurl}}
+                        <a class="mod_boad-profilurl" href="{{profilurl}}">{{commentusername}}</a>
+                    {{/profilurl}}
+                    {{^profilurl}}
+                        {{commentusername}}
+                    {{/profilurl}}
+                {{/showcommentusername}}
+                {{^showcommentusername}}
+                    (username wird aktuell nicht angezeigt)
+                {{/showcommentusername}}
+            </div>
             {{#candelete}}
                 <a href="#" data-action="deletecomment" class="btn btn-icon d-flex align-items-center justify-content-center icon-no-margin ml-auto" data-commentid="{{id}}">
                     {{#pix}}i/delete, core, {{#str}}deletecomment, mod_board{{/str}}{{/pix}}

--- a/tests/board_test.php
+++ b/tests/board_test.php
@@ -447,7 +447,7 @@ class board_test extends \advanced_testcase {
             'intro' => '',
             'historyid' => 3,
             'background_color' => null,
-                'showcommentusername' => 0,
+            'showcommentusername' => 0,
             'addrating' => 3,
             'hideheaders' => 0,
             'sortby' => 2,

--- a/tests/board_test.php
+++ b/tests/board_test.php
@@ -447,6 +447,7 @@ class board_test extends \advanced_testcase {
             'intro' => '',
             'historyid' => 3,
             'background_color' => null,
+                'showcommentusername' => 0,
             'addrating' => 3,
             'hideheaders' => 0,
             'sortby' => 2,

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'mod_board'; // Full name of the plugin (used for diagnostics).
-$plugin->version   = 2022040109; // The current module version Use 2022.04.01 as base for 4.00.
+$plugin->version   = 2023101902; // The current module version Use 2022.04.01 as base for 4.00.
 $plugin->requires  = 2022041900; // Moodle 4.00 and up.
 $plugin->release = '1.401.00 (Build 2022121200)';
 $plugin->maturity  = MATURITY_BETA;

--- a/view.php
+++ b/view.php
@@ -99,6 +99,11 @@ echo $OUTPUT->header();
 if ($board->enableblanktarget) {
     echo html_writer::tag('div', get_string('blanktargetenabled', 'mod_board'), ['class' => 'small']);
 }
+if ($board->showcommentusername) {
+    echo html_writer::tag('div', get_string('showcommentusernameenabled', 'mod_board'), ['class' => 'small']);
+} else {
+    echo html_writer::tag('div', get_string('showcommentusernamedisabled', 'mod_board'), ['class' => 'small']);
+}
 
 echo $OUTPUT->box_start('mod_introbox', 'group_menu');
 echo groups_print_activity_menu($cm, $pageurl, true);


### PR DESCRIPTION
fix issue #100 featuerrequest: comments should show name of the user to be able to prevent "anonymous" comments