### PR TITLE
WIP: feature #100 - Show author of comment

### DIFF
--- a/backup/moodle2/backup_board_stepslib.php
+++ b/backup/moodle2/backup_board_stepslib.php
@@ -33,7 +33,7 @@ class backup_board_activity_structure_step extends backup_activity_structure_ste
 
         $board = new backup_nested_element('board', array('id'), array(
             'course', 'name', 'timemodified', 'intro', 'introformat', 'historyid',
-            'background_color', 'showcommentusername', 'addrating', 'hideheaders', 'sortby', 'postby', 'userscanedit', 'singleusermode',
+            'background_color', 'showauthorofcomment', 'addrating', 'hideheaders', 'sortby', 'postby', 'userscanedit', 'singleusermode',
             'completionnotes'));
 
         $columns = new backup_nested_element('columns');

--- a/backup/moodle2/backup_board_stepslib.php
+++ b/backup/moodle2/backup_board_stepslib.php
@@ -33,7 +33,7 @@ class backup_board_activity_structure_step extends backup_activity_structure_ste
 
         $board = new backup_nested_element('board', array('id'), array(
             'course', 'name', 'timemodified', 'intro', 'introformat', 'historyid',
-            'background_color', 'addrating', 'hideheaders', 'sortby', 'postby', 'userscanedit', 'singleusermode',
+            'background_color', 'showcommentusername', 'addrating', 'hideheaders', 'sortby', 'postby', 'userscanedit', 'singleusermode',
             'completionnotes'));
 
         $columns = new backup_nested_element('columns');

--- a/backup/moodle2/backup_board_stepslib.php
+++ b/backup/moodle2/backup_board_stepslib.php
@@ -31,10 +31,9 @@ class backup_board_activity_structure_step extends backup_activity_structure_ste
 
         $userinfo = $this->get_setting_value('userinfo');
 
-        $board = new backup_nested_element('board', array('id'), array(
-            'course', 'name', 'timemodified', 'intro', 'introformat', 'historyid',
-            'background_color', 'showauthorofcomment', 'addrating', 'hideheaders', 'sortby', 'postby', 'userscanedit', 'singleusermode',
-            'completionnotes'));
+        $board = new backup_nested_element('board', array('id'), array('course', 'name', 'timemodified', 'intro', 'introformat',
+                'historyid', 'background_color', 'showauthorofcomment', 'addrating', 'hideheaders', 'sortby', 'postby',
+                'userscanedit', 'singleusermode', 'completionnotes'));
 
         $columns = new backup_nested_element('columns');
         $column = new backup_nested_element('column', array('id'), array('boardid', 'name', 'sortorder'));

--- a/classes/board.php
+++ b/classes/board.php
@@ -113,6 +113,7 @@ class board {
                 'size_min' => self::ACCEPTED_FILE_MIN_SIZE,
                 'size_max' => self::ACCEPTED_FILE_MAX_SIZE
             ],
+            'showcommentusername' => self::board_show_commentusername($board->id),
             'ratingenabled' => self::board_rating_enabled($board->id),
             'hideheaders' => self::board_hide_headers($board->id),
             'sortby' => $board->sortby,
@@ -318,7 +319,6 @@ class board {
             AND {board_notes}.deleted = 0";
         return $DB->count_records_sql($sql, ['boardid' => $boardid]) > 0;
     }
-
 
     /**
      * Retrieves the board.
@@ -1145,6 +1145,23 @@ class board {
             'other' => array('columnid' => $columnid)
         ));
         $event->trigger();
+    }
+
+
+
+    /**
+     * Checks to see if showcommentusername has been enabled for the board.
+     *
+     * @param int $boardid
+     * @return bool
+     */
+    public static function board_show_commentusername($boardid) {
+        $board = static::get_board($boardid);
+        if (!$board) {
+            return false;
+        }
+
+        return !empty($board->showcommentusername);
     }
 
     /**

--- a/classes/board.php
+++ b/classes/board.php
@@ -113,7 +113,7 @@ class board {
                 'size_min' => self::ACCEPTED_FILE_MIN_SIZE,
                 'size_max' => self::ACCEPTED_FILE_MAX_SIZE
             ],
-            'showcommentusername' => self::board_show_commentusername($board->id),
+            'showauthorofcomment' => self::board_show_authorofcomment($board->id),
             'ratingenabled' => self::board_rating_enabled($board->id),
             'hideheaders' => self::board_hide_headers($board->id),
             'sortby' => $board->sortby,
@@ -1150,18 +1150,18 @@ class board {
 
 
     /**
-     * Checks to see if showcommentusername has been enabled for the board.
+     * Checks to see if showauthorofcomment has been enabled for the board.
      *
      * @param int $boardid
      * @return bool
      */
-    public static function board_show_commentusername($boardid) {
+    public static function board_show_authorofcomment($boardid) {
         $board = static::get_board($boardid);
         if (!$board) {
             return false;
         }
 
-        return !empty($board->showcommentusername);
+        return !empty($board->showauthorofcomment);
     }
 
     /**

--- a/db/install.xml
+++ b/db/install.xml
@@ -14,6 +14,7 @@
         <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="historyid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="background_color" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="showcommentusername" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="show username of comments to students"/>
         <FIELD NAME="addrating" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="hideheaders" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="show headers to students"/>
         <FIELD NAME="sortby" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -14,7 +14,7 @@
         <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="historyid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="background_color" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="showcommentusername" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="show username of comments to students"/>
+        <FIELD NAME="showauthorofcomment" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="show author of comments to other students"/>
         <FIELD NAME="addrating" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="hideheaders" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="show headers to students"/>
         <FIELD NAME="sortby" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -235,5 +235,20 @@ function xmldb_board_upgrade(int $oldversion) {
         upgrade_mod_savepoint(true, 2022040110, 'board');
     }
 
+    if ($oldversion < 2022040111) {
+
+        // Define field sortorder to be added to board_notes.
+        $table = new xmldb_table('board');
+        $field = new xmldb_field('showcommentusername', XMLDB_TYPE_INTEGER, '1', null, null, null, '0', 'background_color');
+        
+	// Conditionally launch add field sortorder.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Board savepoint reached.
+        upgrade_mod_savepoint(true, 2022040111, 'board');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -239,7 +239,7 @@ function xmldb_board_upgrade(int $oldversion) {
 
         // Define field sortorder to be added to board_notes.
         $table = new xmldb_table('board');
-        $field = new xmldb_field('showcommentusername', XMLDB_TYPE_INTEGER, '1', null, null, null, '0', 'background_color');
+        $field = new xmldb_field('showauthorofcomment', XMLDB_TYPE_INTEGER, '1', null, null, null, '0', 'background_color');
         
 	// Conditionally launch add field sortorder.
         if (!$dbman->field_exists($table, $field)) {

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -235,19 +235,19 @@ function xmldb_board_upgrade(int $oldversion) {
         upgrade_mod_savepoint(true, 2022040110, 'board');
     }
 
-    if ($oldversion < 2022040111) {
+    if ($oldversion < 2022040113) {
 
         // Define field sortorder to be added to board_notes.
         $table = new xmldb_table('board');
         $field = new xmldb_field('showauthorofcomment', XMLDB_TYPE_INTEGER, '1', null, null, null, '0', 'background_color');
-        
-	// Conditionally launch add field sortorder.
+
+        // Conditionally launch add field sortorder.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
         // Board savepoint reached.
-        upgrade_mod_savepoint(true, 2022040111, 'board');
+        upgrade_mod_savepoint(true, 2022040113, 'board');
     }
 
     return true;

--- a/external.php
+++ b/external.php
@@ -684,6 +684,7 @@ class mod_board_external extends external_api {
      */
     public static function get_comments($noteid) {
         global $DB, $USER;
+        $config = get_config('mod_board');
 
         $warnings = [];
         $arrayparams = array(
@@ -726,7 +727,7 @@ class mod_board_external extends external_api {
 
             $authorofcomment = '';
             $profilurl = '';
-            if ($showauthorofcomment) {
+            if ($config->allowshowauthorofcommentsonboard && $showauthorofcomment) {
                 $user = \core_user::get_user($notecomment->userid, 'username, firstname, lastname');
                 $authorofcomment = $user->firstname . " " . $user->lastname;
                 $profilurl = '' . new moodle_url('/user/profile.php', array('id' => $notecomment->userid));

--- a/external.php
+++ b/external.php
@@ -711,7 +711,7 @@ class mod_board_external extends external_api {
         $params['columnid'] = $column->columnid;
         $board = $DB->get_record('board_columns', ['id' => $params['columnid']], 'boardid');
 
-        // $board->boardid Ownerid is not relevant but we use $column->ownerid.
+        // The ownerid of the board with $board->boardid is not relevant. We use $column->ownerid.
         $configuration = board::get_configuration($board->boardid, $column->ownerid);
         $showauthorofcomment = $configuration['showauthorofcomment'];
 

--- a/external.php
+++ b/external.php
@@ -712,7 +712,7 @@ class mod_board_external extends external_api {
 
         // $board->boardid Ownerid is not relevant but we use $column->ownerid.
         $configuration = board::get_configuration($board->boardid, $column->ownerid);
-        $showcommentusername = $configuration['showcommentusername'];
+        $showauthorofcomment = $configuration['showauthorofcomment'];
 
         $notecomments = $DB->get_records('board_comments', ['noteid' => $params['noteid'], 'deleted' => 0], 'timecreated DESC');
         $comments = [];
@@ -722,20 +722,20 @@ class mod_board_external extends external_api {
             $comment->noteid = $notecomment->noteid;
             $comment->content = $notecomment->content;
             $comment->candelete = ($notecomment->userid === $USER->id || $candeleteall) ? true : false;
-            $comment->showcommentusername = $showcommentusername;
+            $comment->showauthorofcomment = $showauthorofcomment;
 
-            $commentusername = '';
+            $authorofcomment = '';
             $profilurl = '';
-            if ($showcommentusername) {
+            if ($showauthorofcomment) {
                 $user = \core_user::get_user($notecomment->userid, 'username, firstname, lastname');
-                $commentusername = $user->firstname . " " . $user->lastname;
+                $authorofcomment = $user->firstname . " " . $user->lastname;
                 $profilurl = '' . new moodle_url('/user/profile.php', array('id' => $notecomment->userid));
             } else {
-                $commentusername = '';
+                $authorofcomment = '';
                 $profilurl = '';
             }
 
-            $comment->commentusername = $commentusername;
+            $comment->authorofcomment = $authorofcomment;
             $comment->profilurl = $profilurl;
 
             $comment->date = userdate($notecomment->timecreated);
@@ -771,8 +771,8 @@ class mod_board_external extends external_api {
                             'id' => new external_value(PARAM_INT, 'The comment id.'),
                             'noteid' => new external_value(PARAM_INT, 'The note id.'),
                             'candelete' => new external_value(PARAM_BOOL, 'Can delete the comment.'),
-                            'showcommentusername' => new external_value(PARAM_BOOL, 'showcommentusername.'),
-                            'commentusername' => new external_value(PARAM_TEXT, 'The username of the comment.'),
+                            'showauthorofcomment' => new external_value(PARAM_BOOL, 'showauthorofcomment.'),
+                            'authorofcomment' => new external_value(PARAM_TEXT, 'The author of the comment.'),
                             'profilurl' => new external_value(PARAM_TEXT, 'The profil url of the user.'),
                             'date' => new external_value(PARAM_TEXT, 'The date of the comment.'),
                             'content' => new external_value(PARAM_RAW, 'The content of the comment.')

--- a/lang/en/board.php
+++ b/lang/en/board.php
@@ -246,3 +246,9 @@ $string['brickfieldlogo'] = 'Powered by Brickfield logo';
 $string['singleusermodenotembed'] = 'Board does not allow a single user board to be embedded. Please change your settings.';
 $string['allowed_singleuser_modes'] = 'Enabled single user modes';
 $string['allowed_singleuser_modes_desc'] = 'Allow/Disallow usage of certain single user modes. Does not affect already created boards';
+
+$string['showcommentusername'] = 'Show comment username';
+$string['showcommentusername_desc'] = 'If activated the username of a comment will be show for each comment.';
+
+$string['showcommentusernameenabled'] = 'Show comment username is enabled.';
+$string['showcommentusernamedisabled'] = 'Show comment username is disabled but can be later activated to see the owner of comments.';

--- a/lang/en/board.php
+++ b/lang/en/board.php
@@ -247,8 +247,8 @@ $string['singleusermodenotembed'] = 'Board does not allow a single user board to
 $string['allowed_singleuser_modes'] = 'Enabled single user modes';
 $string['allowed_singleuser_modes_desc'] = 'Allow/Disallow usage of certain single user modes. Does not affect already created boards';
 
-$string['showcommentusername'] = 'Show comment username';
-$string['showcommentusername_desc'] = 'If activated the username of a comment will be show for each comment.';
+$string['showauthorofcomment'] = 'Show author of comment';
+$string['showauthorofcomment_desc'] = 'If activated the author of a comment will be show for each comment.';
 
-$string['showcommentusernameenabled'] = 'Show comment username is enabled.';
-$string['showcommentusernamedisabled'] = 'Show comment username is disabled but can be later activated to see the owner of comments.';
+$string['showauthorofcommentenabled'] = 'Show author of comment is enabled.';
+$string['showauthorofcommentdisabled'] = 'Show author of comment is disabled but can be later activated to see the owner of comments.';

--- a/lang/en/board.php
+++ b/lang/en/board.php
@@ -247,8 +247,11 @@ $string['singleusermodenotembed'] = 'Board does not allow a single user board to
 $string['allowed_singleuser_modes'] = 'Enabled single user modes';
 $string['allowed_singleuser_modes_desc'] = 'Allow/Disallow usage of certain single user modes. Does not affect already created boards';
 
-$string['showauthorofcomment'] = 'Show author of comment';
-$string['showauthorofcomment_desc'] = 'If activated the author of a comment will be show for each comment.';
+$string['showauthorofcomment'] = 'Show author of comment on board to users';
+$string['showauthorofcomment_help'] = 'If activated the author of a comment will be show for each comment on the board.';
 
 $string['showauthorofcommentenabled'] = 'Show author of comment is enabled.';
 $string['showauthorofcommentdisabled'] = 'Show author of comment is disabled but can be later activated to see the owner of comments.';
+
+$string['allowshowauthorofcommentsonboard'] = 'Allow to activate to show author of comment on boards';
+$string['allowshowauthorofcommentsonboard_desc'] = 'If activated the board can be configured to show the author of a comment on the board or the comments can be hidden to students (Teacher can see owner of comments by using the export).';

--- a/mod_form.php
+++ b/mod_form.php
@@ -70,6 +70,11 @@ class mod_board_mod_form extends moodleform_mod {
         $mform->addElement('filemanager', 'background_image',
                 get_string('background_image', 'mod_board'), null, $filemanageroptions);
 
+        $mform->addElement('advcheckbox', 'showcommentusername', get_string('showcommentusername', 'mod_board'));
+        $mform->addHelpButton('showcommentusername', 'showcommentusername', 'mod_board');
+        $mform->setDefault('showcommentusername', 1);
+        $mform->setType('showcommentusername', PARAM_INT);
+
         $mform->addElement('select', 'addrating', get_string('addrating', 'mod_board'),
            array(
                 board::RATINGDISABLED => get_string('addrating_none', 'mod_board'),

--- a/mod_form.php
+++ b/mod_form.php
@@ -77,9 +77,9 @@ class mod_board_mod_form extends moodleform_mod {
             $mform->addHelpButton('showauthorofcomment', 'showauthorofcomment', 'mod_board');
             $mform->setDefault('showauthorofcomment', 1);
             $mform->setType('showauthorofcomment', PARAM_INT);
-        } else {
-            // Hint: allowshowauthorofcommentsonboard is not allowed in this moodle. showauthorofcomment will be set to 0 by the default database column value.
         }
+        // Hint: No else if allowshowauthorofcommentsonboard is not allowed in this moodle.
+        // Showauthorofcomment will be set to 0 by the default database column value.
 
         $mform->addElement('select', 'addrating', get_string('addrating', 'mod_board'),
            array(

--- a/mod_form.php
+++ b/mod_form.php
@@ -70,10 +70,10 @@ class mod_board_mod_form extends moodleform_mod {
         $mform->addElement('filemanager', 'background_image',
                 get_string('background_image', 'mod_board'), null, $filemanageroptions);
 
-        $mform->addElement('advcheckbox', 'showcommentusername', get_string('showcommentusername', 'mod_board'));
-        $mform->addHelpButton('showcommentusername', 'showcommentusername', 'mod_board');
-        $mform->setDefault('showcommentusername', 1);
-        $mform->setType('showcommentusername', PARAM_INT);
+        $mform->addElement('advcheckbox', 'showauthorofcomment', get_string('showauthorofcomment', 'mod_board'));
+        $mform->addHelpButton('showauthorofcomment', 'showauthorofcomment', 'mod_board');
+        $mform->setDefault('showauthorofcomment', 1);
+        $mform->setType('showauthorofcomment', PARAM_INT);
 
         $mform->addElement('select', 'addrating', get_string('addrating', 'mod_board'),
            array(

--- a/mod_form.php
+++ b/mod_form.php
@@ -70,10 +70,16 @@ class mod_board_mod_form extends moodleform_mod {
         $mform->addElement('filemanager', 'background_image',
                 get_string('background_image', 'mod_board'), null, $filemanageroptions);
 
-        $mform->addElement('advcheckbox', 'showauthorofcomment', get_string('showauthorofcomment', 'mod_board'));
-        $mform->addHelpButton('showauthorofcomment', 'showauthorofcomment', 'mod_board');
-        $mform->setDefault('showauthorofcomment', 1);
-        $mform->setType('showauthorofcomment', PARAM_INT);
+        $config = get_config('mod_board');
+        $allowshowauthorofcommentsonboard = $config->allowshowauthorofcommentsonboard;
+        if ($allowshowauthorofcommentsonboard) {
+            $mform->addElement('advcheckbox', 'showauthorofcomment', get_string('showauthorofcomment', 'mod_board'));
+            $mform->addHelpButton('showauthorofcomment', 'showauthorofcomment', 'mod_board');
+            $mform->setDefault('showauthorofcomment', 1);
+            $mform->setType('showauthorofcomment', PARAM_INT);
+        } else {
+            // Hint: allowshowauthorofcommentsonboard is not allowed in this moodle. showauthorofcomment will be set to 0 by the default database column value.
+        }
 
         $mform->addElement('select', 'addrating', get_string('addrating', 'mod_board'),
            array(

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -336,7 +336,7 @@
         max-width: 300px;
         word-break: break-word;
     }
-    .mod_board_comment_username {
+    .mod_board_comment_author {
         margin-left: 10px;
     }
 }

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -336,6 +336,9 @@
         max-width: 300px;
         word-break: break-word;
     }
+    .mod_board_comment_username {
+        margin-left: 10px;
+    }
 }
 .modtype_board div.flex-fill {
     width: 100%;

--- a/settings.php
+++ b/settings.php
@@ -67,6 +67,13 @@ if ($ADMIN->fulltree) {
         '1'
     ));
 
+    $settings->add(new admin_setting_configcheckbox(
+            'mod_board/allowshowauthorofcommentsonboard',
+            get_string('allowshowauthorofcommentsonboard', 'mod_board'),
+            get_string('allowshowauthorofcommentsonboard_desc', 'mod_board'),
+            '0'
+    ));
+
     $settings->add(new admin_setting_configtext('mod_board/embed_width', get_string('embed_width', 'mod_board'),
                        get_string('embed_width_desc', 'mod_board'), '99%', PARAM_TEXT));
 

--- a/styles.css
+++ b/styles.css
@@ -346,6 +346,10 @@
     word-break: break-word;
 }
 
+.path-mod-board .mod_board_comment_username {
+    margin-left: 10px;
+}
+
 .modtype_board div.flex-fill {
     width: 100%;
 }
@@ -363,3 +367,4 @@ iframe.mod_board-iframe {
 .pagelayout-embedded.path-mod-board .activity-header {
     display: none;
 }
+

--- a/styles.css
+++ b/styles.css
@@ -346,7 +346,7 @@
     word-break: break-word;
 }
 
-.path-mod-board .mod_board_comment_username {
+.path-mod-board .mod_board_comment_author {
     margin-left: 10px;
 }
 

--- a/templates/comments.mustache
+++ b/templates/comments.mustache
@@ -41,9 +41,6 @@
                         <a class="mod_board_profilurl" href="{{profilurl}}">{{authorofcomment}}</a>
                     {{/profilurl}}
                 {{/showauthorofcomment}}
-                {{^showauthorofcomment}}
-                    <!- (author is hidden) -->
-                {{/showauthorofcomment}}
             </div>
             {{#candelete}}
                 <a href="#" data-action="deletecomment" class="btn btn-icon d-flex align-items-center justify-content-center icon-no-margin ml-auto" data-commentid="{{id}}">

--- a/templates/comments.mustache
+++ b/templates/comments.mustache
@@ -25,25 +25,25 @@
         "content": "This is a comment too",
         "date": "Wednesday, 2 January 2019, 12:00 AM",
         "comments": "Comment for testing",
-        "commentusername": "Username of the autor of the Comment",
+        "authorofcomment": "Username of the autor of the Comment",
         "profilurl": "",
         "candelete": true,
-        "showcommentusername": true
+        "showauthorofcomment": true
     }
 }}
 {{#comments}}
     <div class="comment border rounded border-light p-2 mb-2">
         <div class="comment-header d-flex small text-muted">
             <div class="mb-3">{{date}}</div>
-            <div class="mod_board_comment_username">
-                {{#showcommentusername}}
+            <div class="mod_board_comment_author">
+                {{#showauthorofcomment}}
                     {{#profilurl}}
-                        <a class="mod_board_profilurl" href="{{profilurl}}">{{commentusername}}</a>
+                        <a class="mod_board_profilurl" href="{{profilurl}}">{{authorofcomment}}</a>
                     {{/profilurl}}
-                {{/showcommentusername}}
-                {{^showcommentusername}}
-                    <!- (username hidden) -->
-                {{/showcommentusername}}
+                {{/showauthorofcomment}}
+                {{^showauthorofcomment}}
+                    <!- (author is hidden) -->
+                {{/showauthorofcomment}}
             </div>
             {{#candelete}}
                 <a href="#" data-action="deletecomment" class="btn btn-icon d-flex align-items-center justify-content-center icon-no-margin ml-auto" data-commentid="{{id}}">

--- a/templates/comments.mustache
+++ b/templates/comments.mustache
@@ -24,13 +24,27 @@
         "id": 2,
         "content": "This is a comment too",
         "date": "Wednesday, 2 January 2019, 12:00 AM",
-        "candelete": true
+        "comments": "Comment for testing",
+        "commentusername": "Username of the autor of the Comment",
+        "profilurl": "",
+        "candelete": true,
+        "showcommentusername": true
     }
 }}
 {{#comments}}
     <div class="comment border rounded border-light p-2 mb-2">
         <div class="comment-header d-flex small text-muted">
             <div class="mb-3">{{date}}</div>
+            <div class="mod_board_comment_username">
+                {{#showcommentusername}}
+                    {{#profilurl}}
+                        <a class="mod_board_profilurl" href="{{profilurl}}">{{commentusername}}</a>
+                    {{/profilurl}}
+                {{/showcommentusername}}
+                {{^showcommentusername}}
+                    <!- (username hidden) -->
+                {{/showcommentusername}}
+            </div>
             {{#candelete}}
                 <a href="#" data-action="deletecomment" class="btn btn-icon d-flex align-items-center justify-content-center icon-no-margin ml-auto" data-commentid="{{id}}">
                     {{#pix}}i/delete, core, {{#str}}deletecomment, mod_board{{/str}}{{/pix}}

--- a/tests/board_test.php
+++ b/tests/board_test.php
@@ -447,7 +447,7 @@ class board_test extends \advanced_testcase {
             'intro' => '',
             'historyid' => 3,
             'background_color' => null,
-            'showcommentusername' => 0,
+            'showauthorofcomment' => 0,
             'addrating' => 3,
             'hideheaders' => 0,
             'sortby' => 2,

--- a/tests/board_test.php
+++ b/tests/board_test.php
@@ -447,6 +447,7 @@ class board_test extends \advanced_testcase {
             'intro' => '',
             'historyid' => 3,
             'background_color' => null,
+            'showcommentusername' => 0,
             'addrating' => 3,
             'hideheaders' => 0,
             'sortby' => 2,

--- a/version.php
+++ b/version.php
@@ -25,7 +25,8 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'mod_board'; // Full name of the plugin (used for diagnostics).
-$plugin->version   = 2023101903; // The current module version Use 2022.04.01 as base for 4.00.
+// $plugin->version   = 2022040110; // The current module version Use 2022.04.01 as base for 4.00.
+$plugin->version   = 2022040113; // 2022040113 for developing the new feature "show author of note", should be adapted
 $plugin->requires  = 2022041900; // Moodle 4.00 and up.
 $plugin->release = '1.401.00 (Build 2022121200)';
 $plugin->maturity  = MATURITY_BETA;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'mod_board'; // Full name of the plugin (used for diagnostics).
-$plugin->version   = 2022040111; // The current module version Use 2022.04.01 as base for 4.00.
+$plugin->version   = 2023101903; // The current module version Use 2022.04.01 as base for 4.00.
 $plugin->requires  = 2022041900; // Moodle 4.00 and up.
 $plugin->release = '1.401.00 (Build 2022121200)';
 $plugin->maturity  = MATURITY_BETA;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'mod_board'; // Full name of the plugin (used for diagnostics).
-$plugin->version   = 2022040110; // The current module version Use 2022.04.01 as base for 4.00.
+$plugin->version   = 2022040111; // The current module version Use 2022.04.01 as base for 4.00.
 $plugin->requires  = 2022041900; // Moodle 4.00 and up.
 $plugin->release = '1.401.00 (Build 2022121200)';
 $plugin->maturity  = MATURITY_BETA;

--- a/view.php
+++ b/view.php
@@ -81,7 +81,7 @@ if (($board->singleusermode != board::SINGLEUSER_DISABLED)
 $PAGE->requires->js_call_amd('mod_board/main', 'initialize',
     [
     'boardid' => $board->id,
-    'ownerid' => $ownerid
+    'ownerid' => $ownerid,
     ]
 );
 
@@ -155,7 +155,7 @@ if (($board->singleusermode == board::SINGLEUSER_PUBLIC || $board->singleusermod
             ['style' => 'display: block !important; width: 140px;']);
         $img .= html_writer::tag('span', get_string('opensinnewwindow', 'mod_board'), ['class' => 'sr-only']);
         echo html_writer::link('https://www.brickfield.ie/docs/mod_board/', $img, ['target' => '_blank',
-            'style' => 'margin-left: auto; margin-right: 90px; display: block !important; width: 140px;']);
+            'style' => 'margin-left: auto; margin-right: 90px; display: block !important; width: 140px;', ]);
     }
     echo '</div>';
 }

--- a/view.php
+++ b/view.php
@@ -99,10 +99,10 @@ echo $OUTPUT->header();
 if ($board->enableblanktarget) {
     echo html_writer::tag('div', get_string('blanktargetenabled', 'mod_board'), ['class' => 'small']);
 }
-if ($board->showcommentusername) {
-    echo html_writer::tag('div', get_string('showcommentusernameenabled', 'mod_board'), ['class' => 'small']);
+if ($board->showauthorofcomment) {
+    echo html_writer::tag('div', get_string('showauthorofcommentenabled', 'mod_board'), ['class' => 'small']);
 } else {
-    echo html_writer::tag('div', get_string('showcommentusernamedisabled', 'mod_board'), ['class' => 'small']);
+    echo html_writer::tag('div', get_string('showauthorofcommentdisabled', 'mod_board'), ['class' => 'small']);
 }
 
 echo $OUTPUT->box_start('mod_introbox', 'group_menu');

--- a/view.php
+++ b/view.php
@@ -99,6 +99,11 @@ echo $OUTPUT->header();
 if ($board->enableblanktarget) {
     echo html_writer::tag('div', get_string('blanktargetenabled', 'mod_board'), ['class' => 'small']);
 }
+if ($board->showcommentusername) {
+    echo html_writer::tag('div', get_string('showcommentusernameenabled', 'mod_board'), ['class' => 'small']);
+} else {
+    echo html_writer::tag('div', get_string('showcommentusernamedisabled', 'mod_board'), ['class' => 'small']);
+}
 
 echo $OUTPUT->box_start('mod_introbox', 'group_menu');
 echo groups_print_activity_menu($cm, $pageurl, true);


### PR DESCRIPTION
Fix: #100 
This pull request adds the feature that a siteadmin can activate the feature to show the author of a comment.
The teacher in a course can configure to hide (default) or show the autor.
Above the board the users can see an information if or if not the author will be displayed depending on the configuration of the board.

In line 707 or 720   
`foreach ($notes as $note)` 
does not loop the notes but it loops the comments. 
So we we changed the loop to
`foreach ($notecomments as $notecomment) `
This does not not fix #25 if post does not mean comment on notes.

To show author of notes added to the board a similar implementation will be added different be a pull request.
