### PR TITLE
added suffix to completion rules, fixes #109

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -177,16 +177,25 @@ class mod_board_mod_form extends moodleform_mod {
      * @return array Array of string IDs of added items, empty array if none
      */
     public function add_completion_rules() {
+        global $CFG;
+
         $mform =& $this->_form;
 
-        $group = [];
-        $group[] =& $mform->createElement('checkbox', 'completionnotesenabled', '', get_string('completionnotes', 'mod_board'));
-        $group[] =& $mform->createElement('text', 'completionnotes', '', ['size' => 3]);
-        $mform->setType('completionnotes', PARAM_INT);
-        $mform->addGroup($group, 'completionnotesgroup', get_string('completionnotesgroup', 'mod_board'), [' '], false);
-        $mform->disabledIf('completionnotes', 'completionnotesenabled', 'notchecked');
+        // Changes for Moodle 4.3 - MDL-78516.
+        if ($CFG->branch < 403) {
+            $suffix = '';
+        } else {
+            $suffix = $this->get_suffix();
+        }
 
-        return ['completionnotesgroup'];
+        $group = [];
+        $group[] =& $mform->createElement('checkbox', 'completionnotesenabled' . $suffix, '', get_string('completionnotes', 'mod_board'));
+        $group[] =& $mform->createElement('text', 'completionnotes' . $suffix, '', ['size' => 3]);
+        $mform->setType('completionnotes' . $suffix, PARAM_INT);
+        $mform->addGroup($group, 'completionnotesgroup' . $suffix, get_string('completionnotesgroup', 'mod_board'), [' '], false);
+        $mform->disabledIf('completionnotes' . $suffix, 'completionnotesenabled', 'notchecked');
+
+        return ['completionnotesgroup' . $suffix];
     }
 
     /**


### PR DESCRIPTION
Since Moodle 4.3 the addition of a suffix is required for completion rules: 
https://moodledev.io/docs/4.3/devupdate#append-a-suffix-to-the-completion-rules
This will fix #109