### PR TITLE
MBS-8688: Change embed mode to work in Moodle 4.3

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -499,7 +499,8 @@ function board_cm_info_view(cm_info $cm) {
     if ($board->embed) {
         $width = get_config('mod_board', 'embed_width');
         $height = get_config('mod_board', 'embed_height');
-        $output = html_writer::tag('h3', $board->name);
+        $output = html_writer::start_tag('div', ['class' => 'mod_board_embed_container']);
+        $output .= html_writer::tag('h3', $board->name);
         $output .= html_writer::start_tag('iframe', [
             'src' => new moodle_url('/mod/board/view.php', ['id' => $cm->id, 'embed' => 1]),
             'width' => $width,
@@ -510,6 +511,7 @@ function board_cm_info_view(cm_info $cm) {
         $output .= html_writer::end_tag('iframe');
         $output .= html_writer::link(new moodle_url('/mod/board/view.php', ['id' => $cm->id]),
             get_string('viewboard', 'board'));
+        $output .= html_writer::end_tag('div');
         $cm->set_content($output, true);
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -363,3 +363,7 @@ iframe.mod_board-iframe {
 .pagelayout-embedded.path-mod-board .activity-header {
     display: none;
 }
+
+.mod_board_embed_container {
+    width: 100%;
+}


### PR DESCRIPTION
In Moodle 4.3 / 4.4 embed mode looks like this:
![grafik](https://github.com/brickfield/moodle-mod_board/assets/26581385/bad00566-4c18-426d-87a8-327ab604850a)

This patch fixes this.