### PR TITLE
Smaller monologo icon for Moodle ≥ 4.4.

### DIFF
--- a/pix/monologo.svg
+++ b/pix/monologo.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet"><defs><style>.cls-1{fill:none;stroke:#000;stroke-miterlimit:10}</style></defs><path class="cls-1" d="M3.5 3.4h4.3v7.2H3.5zM16.3 3.4h4.3v5.7h-4.3zM9.6 3.4h5v11.7h-5zM3.5 13.1h4.3v7.2H3.5z"/></svg>


### PR DESCRIPTION
This type of monologo.svg is needed starting Moodle 4.4