### PR TITLE
Add support for MSSQL databases

### DIFF
--- a/classes/board.php
+++ b/classes/board.php
@@ -994,7 +994,7 @@ class board {
                 'ownerid' => 0, 'content' => json_encode(array('id' => $id, 'columnid' => $columnid)),
                 'userid' => $USER->id, 'timecreated' => time()));
 
-            $sql = "UPDATE {board_notes} bn
+            $sql = "UPDATE {board_notes}
                        SET sortorder = sortorder - 1
                      WHERE sortorder > :sortorder AND columnid = :columnid";
             $DB->execute($sql, ['sortorder' => $sortorder, 'columnid' => $columnid]);
@@ -1116,15 +1116,15 @@ class board {
             if ($issamecolumn) {
                 $params = ['newsort' => $sortorder, 'oldsort' => $note->sortorder, 'columnid' => $columnid];
                 if ($ismovingup) {
-                    $sql = "UPDATE {board_notes} bn
-                               SET sortorder = bn.sortorder - 1
+                    $sql = "UPDATE {board_notes}
+                               SET sortorder = sortorder - 1
                              WHERE sortorder <= :newsort
                                    AND sortorder >= :oldsort
                                    AND columnid = :columnid";
                     $DB->execute($sql, $params);
                 } else if ($ismovingdown) {
-                    $sql = "UPDATE {board_notes} bn
-                               SET sortorder = bn.sortorder + 1
+                    $sql = "UPDATE {board_notes}
+                               SET sortorder = sortorder + 1
                              WHERE sortorder >= :newsort
                                    AND sortorder <= :oldsort
                                    AND columnid = :columnid";
@@ -1132,12 +1132,12 @@ class board {
                 }
             } else {
                 // Increment the new column notes to fit the moved note.
-                $sql = "UPDATE {board_notes} bn
-                           SET sortorder = bn.sortorder + 1
+                $sql = "UPDATE {board_notes}
+                           SET sortorder = sortorder + 1
                          WHERE sortorder >= :newsort AND columnid = :columnid";
                 $DB->execute($sql, ['newsort' => $sortorder, 'columnid' => $columnid]);
                 // Decrement the old column notes above where the moved note left.
-                $sql = "UPDATE {board_notes} bn
+                $sql = "UPDATE {board_notes}
                            SET sortorder = sortorder - 1
                          WHERE sortorder > :oldsort AND columnid = :columnid";
                 $DB->execute($sql, ['oldsort' => $note->sortorder, 'columnid' => $note->columnid]);


### PR DESCRIPTION
The SQL syntax for MSSQL style databases does not allow the use of table aliases in `UPDATE` statements.

This pull request adds support for MSSQL style databases by removing the redundant `bn` table alias used in update statements called whenever a note is deleted or moved.